### PR TITLE
Mediawiki 1.29

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ Enjoy with [MediaWiki](https://www.mediawiki.org/) + [VisualEditor](https://www.
 Running `sudo docker-compose up` in a checkout of this repository will start containers:
 
 - `db` - A MySQL [container](https://hub.docker.com/r/pastakhov/mysql/), used as the database backend for MediaWiki.
-- `elasticsearch` - An [Elasticsearch](https://www.elastic.co/products/elasticsearch) [container](https://github.com/pastakhov/docker-elasticsearch/), used as the full-text search engine for MediaWiki
+- `elasticsearch` - An [Elasticsearch](https://www.elastic.co/products/elasticsearch) [container](https://hub.docker.com/_/elasticsearch/), used as the full-text search engine for MediaWiki
 - `memcached` - A memory object caching system [container](https://hub.docker.com/_/memcached/), used as the cache system for MediaWiki
 - `parsoid` - A [bidirectional runtime wikitext parser](https://www.mediawiki.org/wiki/Parsoid) [container](https://hub.docker.com/r/pastakhov/parsoid/), used by [VisualEditor](https://www.mediawiki.org/wiki/VisualEditor), [Flow](https://www.mediawiki.org/wiki/Flow) and other [MediaWiki extensions](https://www.mediawiki.org/wiki/Extensions)
 - `proxy` - [Varnish reverse proxy server](https://www.mediawiki.org/wiki/Manual:Varnish_caching) [container](https://github.com/pastakhov/docker-mediawiki-varnish/) which reduces the time taken to serve often-requested pages
 - `restbase` - A [REST storage and service dispatcher](https://www.mediawiki.org/wiki/RESTBase) [container](https://hub.docker.com/r/pastakhov/restbase/)
-- `web` - An Apache/MediaWiki container with PHP 7.0 and MediaWiki 1.28
+- `web` - An Apache/MediaWiki container with PHP 7.0 and MediaWiki 1.29
 
 The elasticsearch, parsoid, restbase, proxy, web containers are based on [Ubuntu](https://hub.docker.com/_/ubuntu/) 16.04
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,7 +85,7 @@ services:
             - RB_CONF_PDF_URI=http://pdf:3000
 
     elasticsearch:
-        image: pastakhov/elasticsearch:2.4.5
+        image: elasticsearch:5.6
         restart: always
 
     pdf:

--- a/web/DockerSettings.php
+++ b/web/DockerSettings.php
@@ -150,7 +150,7 @@ $wgGroupPermissions['sysop']['interwiki'] = true;
 # https://www.mediawiki.org/wiki/Extension:Flow
 $flowNamespaces = getenv( 'MW_FLOW_NAMESPACES' );
 if ( $flowNamespaces ) {
-    require_once "$IP/extensions/Flow/Flow.php"; // REL1_29+ wfLoadExtension( 'Flow' );
+    wfLoadExtension( 'Flow' );
     $wgFlowContentFormat = 'html';
     foreach ( explode( ',', $flowNamespaces ) as $ns ) {
         $wgNamespaceContentModels[ constant( $ns ) ] = 'flow-board';
@@ -158,7 +158,7 @@ if ( $flowNamespaces ) {
 }
 
 wfLoadExtension( 'Thanks' );
-require_once "$IP/extensions/Echo/Echo.php"; // REL1_29+ wfLoadExtension( 'Echo' );
+wfLoadExtension( 'Echo' );
 
 wfLoadExtension( 'CheckUser' );
 $wgGroupPermissions['sysop']['checkuser'] = true;

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -36,7 +36,7 @@ RUN set -x; \
     && rm /var/www/html/index.html \
     && rm -rf /etc/apache2/sites-enabled/*
 
-ENV MW_VERSION=REL1_28 \
+ENV MW_VERSION=REL1_29 \
     MW_HOME=/var/www/html/w \
     MW_VOLUME=/mediawiki \
     WWW_USER=www-data \


### PR DESCRIPTION
Hello,

This is *almost* working.

Basically, upgrades to Mediawiki current release 1.29. I also made other changes that seemed obvious to me, feel free to discuss.

We just need to figure out https://www.mediawiki.org/wiki/Topic:Txbtrd36djyaitfm... but basically, at the moment restarting the web container works (the first time it makes the error and the second time it works).

Hum, I found this: https://gerrit.wikimedia.org/r/#/c/364289/

Looks like it's already fixed and we need to wait? I'm unfamiliar with the mediawiki workflow.