### PR TITLE
Add PDF export

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,14 @@ services:
             - RB_CONF_BASE_URI_TEMPLATE=http://{domain}/api/rest_v1
             - RB_CONF_API_URI_TEMPLATE=http://{domain}/w/api.php
             - RB_CONF_LOGGING_LEVEL=info #trace
+            - RB_CONF_PDF_URI=http://pdf:3000
 
     elasticsearch:
         image: pastakhov/elasticsearch:2.4.5
         restart: always
+
+    pdf:
+        image: msokk/electron-render-service
+        restart: always
+        environment:
+            RENDERER_ACCESS_KEY: secret

--- a/web/DockerSettings.php
+++ b/web/DockerSettings.php
@@ -257,5 +257,8 @@ wfLoadExtension('MultimediaViewer');
 wfLoadExtension( 'MobileFrontend' );
 $wgMFAutodetectMobileView = true;
 
+######################### ElectronPdfService ##########################
+wfLoadExtension('ElectronPdfService');
+
 ######################### Custom Settings ##########################
 @include( 'CustomSettings.php' );

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -148,6 +148,11 @@ RUN set -x; \
     cd $MW_HOME/extensions \
     && git clone --depth 1 -b $MW_VERSION https://gerrit.wikimedia.org/r/p/mediawiki/extensions/MobileFrontend
 
+##### ElectronPdfService extension
+RUN set -x; \
+    cd $MW_HOME/extensions \
+    && git clone --depth 1 -b $MW_VERSION https://gerrit.wikimedia.org/r/p/mediawiki/extensions/ElectronPdfService
+
 #### Run maintenance sripts
 # Increase value for run maintenance script before web service started
 ENV MW_AUTOUPDATE=true \


### PR DESCRIPTION
Works in 1.28, does not work on 1.29.

This is because in 1.28 it bypasses the RESTBASE api and queries the electron service directly.

I'm not familiar enough with RESTBASE to know what to do at the moment, but I'll look.

Let's discuss what needs to be done and then maybe we can merge this.