### PR TITLE
MediaWiki 1.30 and other changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,22 @@ Enjoy with [MediaWiki](https://www.mediawiki.org/) + [VisualEditor](https://www.
 Running `sudo docker-compose up` in a checkout of this repository will start containers:
 
 - `db` - A MySQL [container](https://hub.docker.com/r/pastakhov/mysql/), used as the database backend for MediaWiki.
-- `elasticsearch` - An [Elasticsearch](https://www.elastic.co/products/elasticsearch) [container](https://hub.docker.com/_/elasticsearch/), used as the full-text search engine for MediaWiki
+- `elasticsearch` - An [Elasticsearch](https://www.elastic.co/products/elasticsearch) [container](https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html), used as the full-text search engine for MediaWiki
 - `memcached` - A memory object caching system [container](https://hub.docker.com/_/memcached/), used as the cache system for MediaWiki
 - `parsoid` - A [bidirectional runtime wikitext parser](https://www.mediawiki.org/wiki/Parsoid) [container](https://hub.docker.com/r/pastakhov/parsoid/), used by [VisualEditor](https://www.mediawiki.org/wiki/VisualEditor), [Flow](https://www.mediawiki.org/wiki/Flow) and other [MediaWiki extensions](https://www.mediawiki.org/wiki/Extensions)
 - `proxy` - [Varnish reverse proxy server](https://www.mediawiki.org/wiki/Manual:Varnish_caching) [container](https://github.com/pastakhov/docker-mediawiki-varnish/) which reduces the time taken to serve often-requested pages
 - `restbase` - A [REST storage and service dispatcher](https://www.mediawiki.org/wiki/RESTBase) [container](https://hub.docker.com/r/pastakhov/restbase/)
 - `web` - An Apache/MediaWiki container with PHP 7.0 and MediaWiki 1.29
 
-The elasticsearch, parsoid, restbase, proxy, web containers are based on [Ubuntu](https://hub.docker.com/_/ubuntu/) 16.04
+The parsoid, restbase, proxy, web containers are based on [Ubuntu](https://hub.docker.com/_/ubuntu/) 16.04
+
+The ElasticSearch container has requirements reguarding `vm.max_map_count`, and thus you need to do the following:
+
+``` sh
+sysctl -w vm.max_map_count=262144
+```
+
+You can also permanently set this setting by putting the file `etc/sysctl.d/99-elasticsearch.conf` on the root filesystem and doing `sysctl -p` or rebooting.
 
 ## Settings
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,8 +85,14 @@ services:
             - RB_CONF_PDF_URI=http://pdf:3000
 
     elasticsearch:
-        image: elasticsearch:5.6
+        image: docker.elastic.co/elasticsearch/elasticsearch:5.6.8
         restart: always
+        environment:
+            - "xpack.graph.enabled=false"
+            - "xpack.ml.enabled=false"
+            - "xpack.monitoring.enabled=false"
+            - "xpack.security.enabled=false"
+            - "xpack.watcher.enabled=false"
 
     pdf:
         image: msokk/electron-render-service

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,6 +93,7 @@ services:
             - "xpack.monitoring.enabled=false"
             - "xpack.security.enabled=false"
             - "xpack.watcher.enabled=false"
+            - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
 
     pdf:
         image: msokk/electron-render-service

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,8 +24,7 @@ services:
 
     web:
         build: 
-            context: ./web
-            dockerfile: Dockerfile
+            context: web
         restart: always
         depends_on:
             - db

--- a/etc/sysctl.d/99-elasticsearch.conf
+++ b/etc/sysctl.d/99-elasticsearch.conf
@@ -1,0 +1,1 @@
+vm.max_map_count=262144

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -36,7 +36,7 @@ RUN set -x; \
     && rm /var/www/html/index.html \
     && rm -rf /etc/apache2/sites-enabled/*
 
-ENV MW_VERSION=REL1_29 \
+ENV MW_VERSION=REL1_30 \
     MW_HOME=/var/www/html/w \
     MW_VOLUME=/mediawiki \
     WWW_USER=www-data \

--- a/web/run-apache.sh
+++ b/web/run-apache.sh
@@ -109,7 +109,7 @@ run_script_if_needed () {
     fi
 }
 
-chown -R $WWW_USER:$WWW_GROUP $MW_VOLUME $MW_HOME
+chown -R $WWW_USER:$WWW_GROUP $MW_HOME/images
 
 cd $MW_HOME
 


### PR DESCRIPTION
Hello,

Everything is pretty much self-explanatory, I'll let you review and ask questions if needed.

The only somewhat annoying change is the official ElasticSearch image, which requires `vm.max_map_count=262144`.